### PR TITLE
New sponsor page layout 

### DIFF
--- a/_includes/sponsor.html
+++ b/_includes/sponsor.html
@@ -1,4 +1,36 @@
-<li>
-    <a href="{{ include.url | absolute_url}}" target="_blank"><h3>{{ include.name }}</h3></a>
-    <img src="{{ "" | absolute_url }}/assets/images/{{ include.file}}" width='300px'/>
-</li>
+<style>
+    #container {
+        display: flex;
+        flex-direction: row;
+        height: 100%;
+        margin-bottom: 40px;
+    }
+
+    #left-container {
+        width: 250px;
+        margin-right: 30px;
+    }
+
+    .content {
+        height: 100%;
+    }
+
+    #right {
+        flex-grow: 1;
+    }
+</style>
+
+<div id="container">
+    <div id="left-container">
+        <div class="content">
+            <img src="{{ " " | absolute_url }}/assets/images/{{ include.file}}" width='250px' />
+        </div>
+    </div>
+    <div id="right">
+        <div class="content">
+            <h3>{{ include.name }}</h3>
+            <a href="{{ include.url | absolute_url}}" target="_blank">{{ include.url | absolute_url }}</a>
+            <p>{{ include.desc }}</p>
+        </div>
+    </div>
+</div>

--- a/pages/sponsors.md
+++ b/pages/sponsors.md
@@ -12,7 +12,7 @@ Download the [Sponsor Prospectus](https://pydata.org/wp-content/uploads/2019/04/
 
 ## Hosts
 <ul>
-    {% include sponsor.html name="Booking.com" url="https://booking.com" file="sponsors/booking.svg" 
+    {% include sponsor.html name="Booking.com" url="https://booking.com" file="sponsors/booking.png" 
        desc="
        <p>Booking.com is one of the world’s largest e-commerce companies, and the number one destination to book any type of accommodation. Our mission is to empower people to experience the world. Helping us do this is a diverse community of over 17,000 employees across 200+ global offices, all connected by a love of travel and a passion for innovation.</p>
        

--- a/pages/sponsors.md
+++ b/pages/sponsors.md
@@ -11,9 +11,21 @@ Download the [Sponsor Prospectus](https://pydata.org/wp-content/uploads/2019/04/
 
 
 ## Hosts
-<ul class="features">
-    {% include sponsor.html name="Booking.com" url="https://booking.com" file="sponsors/booking.png" %}
-    {% include sponsor.html name="GoDataDriven" url="https://godatadriven.com" file="sponsors/gdd.png" %}
+<ul>
+    {% include sponsor.html name="Booking.com" url="https://booking.com" file="sponsors/booking.svg" 
+       desc="
+       <p>Booking.com is one of the world’s largest e-commerce companies, and the number one destination to book any type of accommodation. Our mission is to empower people to experience the world. Helping us do this is a diverse community of over 17,000 employees across 200+ global offices, all connected by a love of travel and a passion for innovation.</p>
+       
+       <p>Want to help us in this mission? Join us as a data scientist or software developer in our headquarters on a beautiful canal in Amsterdam! Check us out on <a href='https://careers.booking.com/' target='_blank'>https://careers.booking.com/</a>. </p>" %}
+    {% include sponsor.html name="GoDataDriven" url="https://godatadriven.com" file="sponsors/gdd.png" 
+       desc="
+       <p>Established in 2009, GoDataDriven is on the forefront of Big Data innovation. The team consists of a unique combination of experienced Data Scientists, excellent Data Engineers, all with state-of-the-art know-how of technology. Team members of GoDataDriven are characterised by a natural curiosity, pragmatic approach, learning capacity and well-developed communication skills.</p>
+       <p>Whether it is search optimization for an e-retailer, predictive maintenance for a public transportation company, fraud detection for a bank or supply chain management for a production company; GoDataDriven’s Big Data solutions add to the bottom-line of any business.</p>
+       <p>We enjoy working closely with our clients of GoDataDriven include Wehkamp, Bol.com, KLM, ING, Rabobank, Bakkersland and NPO.</p>
+       <p>GoDataDriven is proudly part of Xebia Group.</p>
+       "
+    
+    %}
 </ul>
 
 


### PR DESCRIPTION
The previous one looked like this:

![image](https://user-images.githubusercontent.com/3510863/71764594-f1f75f80-2ee9-11ea-9fdc-92f7ff22c1c1.png)

but this was troublesome with different sized logos as well as for adding descriptions of our sponsors. I propose changing it to this:

![image](https://user-images.githubusercontent.com/3510863/71764597-09364d00-2eea-11ea-9c81-0859c83ad4e8.png)
