### PR TITLE
Change iframe width to 100%

### DIFF
--- a/_includes/section-two.html
+++ b/_includes/section-two.html
@@ -5,7 +5,7 @@
 	<section class="spotlight">
 		<div class="image">
 			{% if post.youtube %}
-				<iframe width="560" height="370" src={{ post.youtube }} frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+				<iframe width="100%" height="370" src={{ post.youtube }} frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 			{% endif %}
 			{% if post.image %}
 				<img src="{% if site.featured-image-source %}{{ post.image | prepend: site.featured-image-source | absolute_url }}{% else %}{{ "" | absolute_url }}/assets/images/{{ post.image }}{% endif %}" alt="" />


### PR DESCRIPTION
The video width was given in pixels. Therefore it was too big on mobile:

<img width="388" alt="mobile-website-before" src="https://user-images.githubusercontent.com/5946784/72009759-716c9200-324e-11ea-95b2-06bd6cc0f46d.png">

![screenshot-phone1](https://user-images.githubusercontent.com/5946784/72009861-a4168a80-324e-11ea-87d6-9cfcf4d3b8e0.png)

Now it is 100%, and it fits better

<img width="411" alt="mobile-website-after" src="https://user-images.githubusercontent.com/5946784/72009885-a973d500-324e-11ea-8464-0eeaf7877ed8.png">

