### PR TITLE
Change meetup to conference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,9 @@ greeting:
     and emerging technologies for data management, processing, analytics, and visualization.
     PyData communities approach data science using many languages, including (but not limited to) Python, Julia, and R.<br /><br />
 
-    The PyData Code of Conduct governs this meetup. To discuss any issues or concerns relating to the code of
-    conduct or the behavior of anyone at a PyData meetup, please contact NumFOCUS Executive Director Leah Silen
-    (+1 512-222-5449; leah@numfocus.org ) or the local organisers at amsterdam@pydata.org.
+    The PyData Code of Conduct governs this conference. To discuss any issues or concerns relating to the code of
+    conduct or the behavior of anyone at a PyData conference (or meetup), please contact NumFOCUS Executive Director 
+    Leah Silen (+1 512-222-5449; leah@numfocus.org ) or the local organisers at amsterdam@pydata.org.
 
 social:
   twitter: https://twitter.com/PyDataAmsterdam


### PR DESCRIPTION
Code of conduct was refering to a meetup, which should be a conference.