### PR TITLE
fix mobile layout "about numfocus" page

### DIFF
--- a/_includes/project.html
+++ b/_includes/project.html
@@ -1,10 +1,4 @@
-<li style="width: 20%;
-    padding-left: 30px;
-    padding-top: 30px;
-    padding-bottom: 30px;
-    padding-right: 30px;
-    text-align: center
-">
+<li class="project">
     {% if include.altname %}
         <a href="https://www.numfocus.org/project/{{include.altname | downcase }}" target="_blank">
     {% else %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2359,7 +2359,6 @@
 		}
 
 /* Features */
-
 	.features {
 		display: -moz-flex;
 		display: -webkit-flex;
@@ -2434,7 +2433,17 @@
 					}
 
 			}
+			@media screen and (min-width: 736px) {
+				.features > li.project {
+							width: 20%;
+							padding-left: 30px;
+							padding-top: 30px;
+							padding-bottom: 30px;
+							padding-right: 30px;
+							text-align: center
+			}
 
+		}
 			@media screen and (max-width: 736px) {
 
 				.features li {


### PR DESCRIPTION
fall back to single-column layout on projects section of "about numfocus" page. Fixes #15, now looks like this:

![image](https://user-images.githubusercontent.com/3510863/72097376-8b74a600-331c-11ea-9bee-ff2df9fdaf7c.png)
