### PR TITLE
added when what and where for the conference

### DIFF
--- a/_posts/homepage/2018-04-12-the-conference.md
+++ b/_posts/homepage/2018-04-12-the-conference.md
@@ -6,9 +6,10 @@ description: PyData Amsterdam
 category: [homepage]
 ---
 
-The PyData Amsterdam conference is an annual event which brings together users and developers of open-source software.
+The PyData Amsterdam conference is an annual event which brings together users and developers of open-source software. In addition to all the great talks  and workshops, there is no place like PyData Amsterdam to meet other like-minded people and get to talk to the developers of the libraries we all use and love.
 
-In addition to all the great talks  and workshops, there is no place like PyData Amsterdam to meet other like-minded people
-and get to talk to the developers of the libraries we all use and love.
+Workshops hosted by GoDataDriven -- 12 June
 
-PyData Amsterdam 2020 will take place from June 12 - 15.
+Main Conference hosted by Booking.com -- 13-14 June
+
+Open Source Sprints hosted by Xomnia -- 15 June


### PR DESCRIPTION
Fix for #34, merged the above paragraph to prevent the section from becoming too tall.